### PR TITLE
トップビューのロゴがリンクされていなかった問題を修正

### DIFF
--- a/header.php
+++ b/header.php
@@ -16,9 +16,11 @@
 		<h1 class="title"><a href="<?php echo home_url('/');?>"><?php bloginfo('name');?></a></h1>
 		</div>
 		<div class="pattern"></div>
-		<video autoplay muted loop id="backgroundVideo" >
-		<source src="<?php echo get_stylesheet_directory_uri();?>/videos/alice_demo.mp4" type="video/mp4">
-		</video>
+		<div id="backgroundVideo">
+			<video autoplay muted loop>
+				<source src="<?php echo get_stylesheet_directory_uri();?>/videos/alice_demo.mp4" type="video/mp4">
+			</video>
+		</div>
 	</div>
 	<div id="header">
 		<div class="container">

--- a/style.css
+++ b/style.css
@@ -72,14 +72,22 @@ label{
 	z-index: -6;
 	width:100%;height:auto;
 	min-width:740px;min-height:460px;
+	overflow-y: hidden;/*はみ出してる動画部分を非表示に*/
+}
+
+#backgroundVideo > video{
+	position: absolute;
+	right: 0;left:0;top: 0;
+	width: 100%;height: auto;
 	background-color: #000;
 }
 
 .firstViewArea{
-	z-index: -4;
+	z-index: 0;
 	position: relative;
 	width: 100%;
 	height: 330px;
+	overflow-y: hidden;/*保険*/
 }
 
 .topLink{


### PR DESCRIPTION
`.firstViewArea`の`z-index`を0に指定．
→下に大きくはみ出す原因は`video`がはみ出しているからであることが判明

動画を１つのブロックで囲み，そのブロックからはみ出した分を`overflow-y: hidden;`で隠した．